### PR TITLE
Add Rust and C client support for the verification discovery API

### DIFF
--- a/c-wrapper/c-examples/challenge_response/challenge_response.c
+++ b/c-wrapper/c-examples/challenge_response/challenge_response.c
@@ -2,18 +2,75 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdio.h>
+#include <string.h>
+#include <limits.h>
 
 #include "veraison_client_wrapper.h"
 
 int main(int argc, char *argv[])
 {
+    // Change the example below to the base URL for where the Veraison verifier is
+    // running.
+    const char *base_url = "http://localhost:8080";
+
+    VeraisonVerificationApi *verification_api = NULL;
+    char new_session_endpoint[PATH_MAX] = {0};
     ChallengeResponseSession *session = NULL;
     const unsigned char my_evidence[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
     VeraisonResult status;
     size_t i;
 
+    // Discover the verification API details from the service base URL.
+    status = veraison_get_verification_api(base_url, &verification_api);
+
+    if (status != Ok)
+    {
+        printf("Failed to discover the verification API from %s\n", base_url);
+        goto cleanup;
+    }
+
+    // Display some useful details from the discovery step.
+    printf("Discovered Veraison verification API at %s\n", base_url);
+    printf("The public key for verification: %s\n", verification_api->public_key_pem);
+    printf("The signature algorithm: %s\n", verification_api->algorithm);
+    printf("The available API endpoints:\n");
+
+    // Display the individual API endpoints, and capture the "newChallengeResponseSession"
+    // endpoint, which will be used in the next step.
+    for (i = 0; i < verification_api->endpoint_count; i++)
+    {
+        printf("    %s: %s\n",
+               verification_api->endpoint_list[i].name,
+               verification_api->endpoint_list[i].path);
+
+        if (strcmp(verification_api->endpoint_list[i].name, "newChallengeResponseSession") == 0)
+        {
+            // This is the endpoint that we want to use to make a challenge-response session,
+            // so concatenate this with the base_url.
+            snprintf(new_session_endpoint,
+                     sizeof(new_session_endpoint),
+                     "%s%s",
+                     base_url,
+                     verification_api->endpoint_list[i].path);
+        }
+    }
+    
+    printf("The supported media types:\n");
+
+    for (i = 0; i < verification_api->media_type_count; i++)
+    {
+        printf("    %s\n", verification_api->media_type_list[i]);
+    }
+
+    if (strlen(new_session_endpoint) == 0)
+    {
+        printf("Failed to locate a newChallengeResponseSession entry in the endpoint list.\n");
+        goto cleanup;
+    }
+
+    // Now run the challenge response session, using the discovered endpoint.
     status = open_challenge_response_session(
-        "http://localhost:8080/challenge-response/v1/",
+        new_session_endpoint,
         32,
         NULL,
         &session);
@@ -50,6 +107,7 @@ int main(int argc, char *argv[])
 
     printf("Supplying evidence to server.\n");
 
+    // Supply our evidence.
     status = challenge_response(
         session,
         sizeof(my_evidence),
@@ -62,6 +120,7 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
 
+    // And, finally, display the server's response, which will be a JWT containing an EAR.
     printf("Raw attestation result string from server: %s\n", session->attestation_result);
 
 cleanup:
@@ -74,6 +133,12 @@ cleanup:
         printf("Disposing client session.\n");
         free_challenge_response_session(session);
     }
+
+    if (verification_api != NULL)
+    {
+        veraison_free_verification_api(verification_api);
+    }
+
     printf("Done!\n");
     return (int)status;
 }

--- a/c-wrapper/c-examples/challenge_response/wiremock/mappings/discovery_verification.json
+++ b/c-wrapper/c-examples/challenge_response/wiremock/mappings/discovery_verification.json
@@ -1,0 +1,33 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/.well-known/veraison/verification"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/vnd.veraison.discovery+json"
+        },
+        "jsonBody": {
+            "ear-verification-key": {
+                "crv": "P-256",
+                "kty": "EC",
+                "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
+                "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
+                "alg": "ES256"
+            },
+            "media-types": [
+                "application/eat-cwt; profile=http://arm.com/psa/2.0.0",
+                "application/pem-certificate-chain",
+                "application/vnd.enacttrust.tpm-evidence",
+                "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0",
+                "application/psa-attestation-token"
+            ],
+            "version": "commit-cb11fa0",
+            "service-state": "READY",
+            "api-endpoints": {
+                "newChallengeResponseSession": "/challenge-response/v1/newSession"
+            }
+        }
+    }
+}

--- a/c-wrapper/src/lib.rs
+++ b/c-wrapper/src/lib.rs
@@ -131,9 +131,18 @@ pub struct VeraisonApiEndpoint {
 /// and must be freed by a corresponding call to [`veraison_free_verification_api`].
 #[repr(C)]
 pub struct VeraisonVerificationApi {
+    // The size, in bytes, of the public key's ASN.1 DER encoding.
     public_key_der_size: libc::size_t,
+
+    // A non-NULL pointer to the public key as an ASN.1 DER encoding.
     public_key_der: *const u8,
+
+    // A non-NULL pointer to a NUL-terminated string, providing the public key in
+    // PEM format.
     public_key_pem: *const libc::c_char,
+
+    // A non-NULL pointer to a NUL-terminated string providing the algorithmic scheme
+    // for the EAR signature, such as "ES256".
     algorithm: *const libc::c_char,
 
     /// The number of accepted media types for evidence verification.

--- a/c-wrapper/src/lib.rs
+++ b/c-wrapper/src/lib.rs
@@ -570,7 +570,7 @@ fn safe_get_verification_api(base_url: &str) -> Result<VeraisonVerificationApi, 
         .collect();
 
     let mut shim = ShimVerificationApi {
-        public_key_der_vec: public_key_der_vec,
+        public_key_der_vec,
         public_key_pem_cstring: CString::new(public_key_pem).unwrap(),
         algorithm_cstring: CString::new(algorithm).unwrap(),
         media_type_cstring_vec: media_type_cstrings,
@@ -609,7 +609,7 @@ fn safe_get_verification_api(base_url: &str) -> Result<VeraisonVerificationApi, 
         media_type_count: shim.media_type_ptr_vec.len(),
         media_type_list: shim.media_type_ptr_vec.as_ptr(),
         version: shim.version_cstring.as_ptr(),
-        service_state: service_state,
+        service_state,
         endpoint_count: shim.endpoint_vec.len(),
         endpoint_list: shim.endpoint_vec.as_ptr(),
         message: shim.message_cstring.as_ptr(),

--- a/c-wrapper/src/lib.rs
+++ b/c-wrapper/src/lib.rs
@@ -499,9 +499,8 @@ pub unsafe extern "C" fn veraison_get_verification_api(
 
     let api = safe_get_verification_api(url_str);
 
-    match api {
-        Ok(_) => {}
-        Err(e) => return stub_verification_api_from_error(&e, out_api),
+    if let Err(e) = api {
+        return stub_verification_api_from_error(&e, out_api);
     }
 
     let api = api.unwrap();

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.13.0"
 thiserror = "1"
 serde = "1.0.144"
 chrono = "0.4"
+jsonwebkey = { version = "0.3.5", features = ["pkcs-convert"] }
 
 [dependencies.serde_with]
 version = "1.14.0"

--- a/rust-client/examples/challenge_response.rs
+++ b/rust-client/examples/challenge_response.rs
@@ -18,11 +18,24 @@ fn my_evidence_builder(nonce: &[u8], accept: &[String]) -> Result<(Vec<u8>, Stri
 }
 
 fn main() {
-    let api_endpoint = "http://127.0.0.1:8080/challenge-response/v1/".to_string();
+    let base_url = "http://127.0.0.1:8080";
+
+    let discovery = Discovery::from_base_url(String::from(base_url))
+        .expect("Failed to start API discovery with the service.");
+
+    let verification_api = discovery
+        .get_verification_api()
+        .expect("Failed to discover the verification endpoint details.");
+
+    let relative_endpoint = verification_api
+        .get_api_endpoint("newChallengeResponseSession")
+        .expect("Could not locate a newChallengeResponseSession endpoint.");
+
+    let api_endpoint = format!("{}{}", base_url, relative_endpoint);
 
     // create a ChallengeResponse object
     let cr = ChallengeResponseBuilder::new()
-        .with_base_url(api_endpoint)
+        .with_new_session_url(api_endpoint)
         .build()
         .unwrap();
 

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -369,6 +369,13 @@ impl VerificationApi {
     pub fn get_api_endpoint(&self, endpoint_name: &str) -> Option<String> {
         self.api_endpoints.get(endpoint_name).cloned()
     }
+
+    pub fn get_all_api_endpoints(&self) -> Vec<(String, String)> {
+        self.api_endpoints
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
 }
 
 pub struct Discovery {

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -329,6 +329,7 @@ pub struct VerificationApi {
 }
 
 impl VerificationApi {
+    /// Obtains the EAR verification public key encoded in ASN.1 DER format.
     pub fn ear_verification_key_as_der(&self) -> Result<Vec<u8>, Error> {
         let key = &self.ear_verification_key.key;
         (*key)
@@ -336,6 +337,7 @@ impl VerificationApi {
             .map_err(|e| Error::DataConversionError(e.to_string()))
     }
 
+    /// Obtains the EAR verification public key encoded in PEM format.
     pub fn ear_verification_key_as_pem(&self) -> Result<String, Error> {
         let key = &self.ear_verification_key.key;
         (*key)
@@ -343,6 +345,7 @@ impl VerificationApi {
             .map_err(|e| Error::DataConversionError(e.to_string()))
     }
 
+    /// Obtains the signature algorithm scheme used with the EAR.
     pub fn ear_verification_algorithm(&self) -> String {
         match &self.ear_verification_key.algorithm {
             Some(alg) => match alg {
@@ -354,22 +357,37 @@ impl VerificationApi {
         }
     }
 
+    /// Obtains the strings for the set of media types that are supported for evidence
+    /// verification. Each member of the array will be a media type string such as
+    /// `"application/eat-cwt; profile=http://arm.com/psa/2.0.0"`.
     pub fn media_types(&self) -> &[String] {
         self.media_types.as_ref()
     }
 
+    /// Obtains the version of the service.
     pub fn version(&self) -> &str {
         self.version.as_ref()
     }
 
+    /// Indicates whether the service is starting, ready, terminating or down.
     pub fn service_state(&self) -> &ServiceState {
         &self.service_state
     }
 
+    /// Gets the API endpoint associated with a specific endpoint name.
+    ///
+    /// Returns `None` if there is no API endpoint with the given name, otherwise returns
+    /// a relative URL such as `"/challenge-response/v1/newSession"`.
     pub fn get_api_endpoint(&self, endpoint_name: &str) -> Option<String> {
         self.api_endpoints.get(endpoint_name).cloned()
     }
 
+    /// Gets all of the API endpoints published by this verification service as a vector of
+    /// string pairs.
+    ///
+    /// For each endpoint entry, the first member of the pair is the endpoint name, such
+    /// as `"newChallengeResponseSession"`, and the second member is the corresponding
+    /// relative URL, such as `"/challenge-response/v1/newSession"`.
     pub fn get_all_api_endpoints(&self) -> Vec<(String, String)> {
         self.api_endpoints
             .iter()
@@ -378,6 +396,11 @@ impl VerificationApi {
     }
 }
 
+/// This structure allows Veraison endpoints and service capabilities to be discovered
+/// dynamically.
+///
+/// Use [`Discovery::from_base_url()`] to create an instance of this structure for the
+/// Veraison service instance that you are communicating with.
 pub struct Discovery {
     provisioning_url: url::Url, //TODO: The provisioning URL discovery is not implemented yet.
     verification_url: url::Url,
@@ -385,6 +408,8 @@ pub struct Discovery {
 }
 
 impl Discovery {
+    /// Establishes client API discovery for the Veraison service instance running at the
+    /// given base URL.
     pub fn from_base_url(base_url_str: String) -> Result<Discovery, Error> {
         let base_url =
             url::Url::parse(&base_url_str).map_err(|e| Error::ConfigError(e.to_string()))?;
@@ -402,6 +427,7 @@ impl Discovery {
         })
     }
 
+    /// Obtains the capabilities and endpoints of the Veraison verification service.
     pub fn get_verification_api(&self) -> Result<VerificationApi, Error> {
         let response = self
             .http_client

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -417,12 +417,12 @@ impl Discovery {
         let mut provisioning_url = base_url.clone();
         provisioning_url.set_path(".well-known/veraison/provisioning");
 
-        let mut verification_url = base_url.clone();
+        let mut verification_url = base_url;
         verification_url.set_path(".well-known/veraison/verification");
 
         Ok(Discovery {
-            provisioning_url: provisioning_url,
-            verification_url: verification_url,
+            provisioning_url,
+            verification_url,
             http_client: reqwest::blocking::Client::builder().build()?,
         })
     }


### PR DESCRIPTION
Allows Rust and C callers to obtain characteristics, capabilities and API endpoints of the Veraison verifier given a base service URL.

Example codes updated in both Rust and C to show how to use discovery in advance of creating the challenge-response session.

Discovery of provisioning API not yet supported, but the API framework is structured such that this would be a natural extension.

FFI coding conventions are based on the patterns already established by the existing C client layer.

Signed-off-by: Paul Howard <paul.howard@arm.com>