### PR TITLE
Add a string getter for the verification key

### DIFF
--- a/c-wrapper/src/lib.rs
+++ b/c-wrapper/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::multiple_crate_versions)]
+
 use std::ffi::{c_void, CStr, CString};
 
 use core::slice;

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::multiple_crate_versions)]
+
 #[derive(thiserror::Error, PartialEq, Eq)]
 pub enum Error {
     #[error("configuration error: {0}")]

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -345,6 +345,11 @@ impl VerificationApi {
             .map_err(|e| Error::DataConversionError(e.to_string()))
     }
 
+    /// Obtains the EAR verification public key as a JSON string.
+    pub fn ear_verification_key_as_string(&self) -> String {
+        self.ear_verification_key.to_string()
+    }
+
     /// Obtains the signature algorithm scheme used with the EAR.
     pub fn ear_verification_algorithm(&self) -> String {
         match &self.ear_verification_key.algorithm {


### PR DESCRIPTION
Public getters for the verification key were previously available as PEM or DER, but it's also useful to have the simple JSON string, especially since this is what the rust-ear library consumes.

Signed-off-by: Paul Howard <paul.howard@arm.com>