### PR TITLE
feat: Support obtaining signed CoSERV responses through the API client.

### DIFF
--- a/src/coserv.rs
+++ b/src/coserv.rs
@@ -97,9 +97,9 @@ impl QueryRunnerBuilder {
 
         let mut http_client_builder: ClientBuilder = reqwest::ClientBuilder::new();
 
-        if self.root_certificate.is_some() {
+        if let Some(root_cert) = self.root_certificate {
             let mut buf = Vec::new();
-            File::open(self.root_certificate.unwrap())?.read_to_end(&mut buf)?;
+            File::open(root_cert)?.read_to_end(&mut buf)?;
             let cert = Certificate::from_pem(&buf)?;
             http_client_builder = http_client_builder.add_root_certificate(cert);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,9 @@ impl ChallengeResponseBuilder {
 
         let mut http_client_builder: ClientBuilder = reqwest::ClientBuilder::new();
 
-        if self.root_certificate.is_some() {
+        if let Some(root_cert) = self.root_certificate {
             let mut buf = Vec::new();
-            File::open(self.root_certificate.unwrap())?.read_to_end(&mut buf)?;
+            File::open(root_cert)?.read_to_end(&mut buf)?;
             let cert = Certificate::from_pem(&buf)?;
             http_client_builder = http_client_builder.add_root_certificate(cert);
         }
@@ -433,9 +433,9 @@ impl DiscoveryBuilder {
 
         let mut http_client_builder: ClientBuilder = reqwest::ClientBuilder::new();
 
-        if self.root_certificate.is_some() {
+        if let Some(root_cert) = self.root_certificate {
             let mut buf = Vec::new();
-            File::open(self.root_certificate.unwrap())?.read_to_end(&mut buf)?;
+            File::open(root_cert)?.read_to_end(&mut buf)?;
             let cert = Certificate::from_pem(&buf)?;
             http_client_builder = http_client_builder.add_root_certificate(cert);
         }


### PR DESCRIPTION
- Common code refactored into private method, with media type switching based on the requirement for a signature
- New public method to obtain signed CoSERV response as raw bytes
- New public convenience method to obtain the signed CoSERV and perform the verification inline (with the verifier passed as an argument)
- Unit tests
- Integration tests have been performed manually using the Linaro Veraison server with signed responses.

Signed-off-by: Paul Howard <paul.howard@arm.com>